### PR TITLE
Task-CameraStack: 

### DIFF
--- a/UnityProject/Storybook/Assets/Code/Scripts/Game/GameManager/GameManager.cs
+++ b/UnityProject/Storybook/Assets/Code/Scripts/Game/GameManager/GameManager.cs
@@ -84,6 +84,8 @@ public class GameManager : Photon.PunBehaviour {
             combatManager.SetCombatTeamList(combatTeams);
 
             m_combatInstances.Add(m_combatInstance);
+            CameraManager m_camManager = FindObjectOfType<CameraManager>();
+            m_camManager.SwitchToCombatCamera(); // Switch to combat camera.
         }
     }
 
@@ -104,6 +106,8 @@ public class GameManager : Photon.PunBehaviour {
         // TODO: Change back to just calling Destroy when that is fixed
         PhotonNetwork.Destroy(currentCombatInstance);
         Destroy(currentCombatInstance);
+        CameraManager m_camManager = FindObjectOfType<CameraManager>();
+        m_camManager.SwitchToOverworldCamera(); // Switch to the overworld camera.
 
         //_returnToDungeon();
     }

--- a/UnityProject/Storybook/Assets/Code/Scripts/Game/World/CameraManager.cs
+++ b/UnityProject/Storybook/Assets/Code/Scripts/Game/World/CameraManager.cs
@@ -24,7 +24,7 @@ public class CameraManager : MonoBehaviour {
 
 
     // Move the combatCamera to the top of the camera stack, effectively rendering it "above" the other cameras
-    void SwitchToCombatCamera()
+    public void SwitchToCombatCamera()
     {
         Debug.Log("Switching to CombatCamera");
         m_combatCamera.depth = 1;
@@ -32,7 +32,7 @@ public class CameraManager : MonoBehaviour {
     }
 
     // Move the overworldCamera to the top of the camera stack, effectively rendering it "above" the other cameras
-    void SwitchToOverworldCamera()
+    public void SwitchToOverworldCamera()
     {
         Debug.Log("Switching to OverworldCamera");
         m_combatCamera.depth = 0;


### PR DESCRIPTION
Integrated the camera stack into game code. Entering a combat scene will switch to the CombatCamera, and exiting the combat scene will switch to the OverworldCamera. NOTE: In all scenes using Combats, make sure you have an object like this: GameObject w/attached script: CameraManager.cs, two camera child GameObjects: CombatCamera, OverworldCamera. Initially, make sure OverworldCamera has the higher depth so it is rendered in front.